### PR TITLE
[feat] Clustering 알고리즘을 Dispatch Queue에서 Operation Queue로 변경

### DIFF
--- a/NaverMapA/NaverMapA/Controller/MainViewController+NMFMapViewCameraDelegate.swift
+++ b/NaverMapA/NaverMapA/Controller/MainViewController+NMFMapViewCameraDelegate.swift
@@ -9,23 +9,19 @@ import Foundation
 import NMapsMap
 
 extension MainViewController: NMFMapViewCameraDelegate {
-    
     func mapViewCameraIdle(_ mapView: NMFMapView) {
         let coordBounds = mapView.projection.latlngBounds(fromViewBounds: UIScreen.main.bounds)
-        DispatchQueue.global().async {
-            let bounds = CoordinateBounds(southWestLng: coordBounds.southWestLng,
-                                          northEastLng: coordBounds.northEastLng,
-                                          southWestLat: coordBounds.southWestLat,
-                                          northEastLat: coordBounds.northEastLat)
-
-            let places = self.dataProvider.fetch(bounds: bounds)
-            guard let viewModel = self.viewModel else { return }
-            if self.prevZoomLevel != mapView.zoomLevel { // 애니메이션
-                self.prevZoomLevel = mapView.zoomLevel
-                viewModel.updatePlacesAndAnimation(places: places, bounds: bounds)
-            } else {
-                viewModel.updatePlaces(places: places, bounds: bounds)
-            }
+        let bounds = CoordinateBounds(southWestLng: coordBounds.southWestLng,
+                                      northEastLng: coordBounds.northEastLng,
+                                      southWestLat: coordBounds.southWestLat,
+                                      northEastLat: coordBounds.northEastLat)
+        let places = self.dataProvider.fetch(bounds: bounds)
+        guard let viewModel = self.viewModel else { return }
+        if self.prevZoomLevel != mapView.zoomLevel { // 애니메이션
+            self.prevZoomLevel = mapView.zoomLevel
+            viewModel.updatePlacesAndAnimation(places: places, bounds: bounds)
+        } else {
+            viewModel.updatePlaces(places: places, bounds: bounds)
         }
     }
 }

--- a/NaverMapA/NaverMapA/Controller/MainViewController.swift
+++ b/NaverMapA/NaverMapA/Controller/MainViewController.swift
@@ -41,8 +41,8 @@ class MainViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        //viewModel = MainViewModel(algorithm: ScaleBasedClustering())
-        viewModel = MainViewModel(algorithm: KMeansClustering())
+        viewModel = MainViewModel(algorithm: ScaleBasedClustering())
+        //viewModel = MainViewModel(algorithm: KMeansClustering())
         //viewModel = MainViewModel(algorithm: PenaltyKmeans())
         bindViewModel()
         setupMapView()

--- a/NaverMapA/NaverMapA/Controller/MainViewController.swift
+++ b/NaverMapA/NaverMapA/Controller/MainViewController.swift
@@ -41,9 +41,9 @@ class MainViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        viewModel = MainViewModel(algorithm: ScaleBasedClustering())
+        //viewModel = MainViewModel(algorithm: ScaleBasedClustering())
         //viewModel = MainViewModel(algorithm: KMeansClustering())
-        //viewModel = MainViewModel(algorithm: PenaltyKmeans())
+        viewModel = MainViewModel(algorithm: PenaltyKmeans())
         bindViewModel()
         setupMapView()
         if dataProvider.objectCount == 0 {

--- a/NaverMapA/NaverMapA/Controller/MainViewController.swift
+++ b/NaverMapA/NaverMapA/Controller/MainViewController.swift
@@ -42,8 +42,8 @@ class MainViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         //viewModel = MainViewModel(algorithm: ScaleBasedClustering())
-        //viewModel = MainViewModel(algorithm: KMeansClustering())
-        viewModel = MainViewModel(algorithm: PenaltyKmeans())
+        viewModel = MainViewModel(algorithm: KMeansClustering())
+        //viewModel = MainViewModel(algorithm: PenaltyKmeans())
         bindViewModel()
         setupMapView()
         if dataProvider.objectCount == 0 {

--- a/NaverMapA/NaverMapA/Model/Algorithm/Clusterable.swift
+++ b/NaverMapA/NaverMapA/Model/Algorithm/Clusterable.swift
@@ -7,12 +7,29 @@
 
 import Foundation
 
-protocol Clusterable {
-    
+protocol Clusterable: NSCopying {
+    var places: [Place] { get set }
+    var bounds: CoordinateBounds { get set }
+    var clusters: [Cluster] { get set }
     func execute(places: [Place], bounds: CoordinateBounds) -> [Cluster]
+    func run()
 }
 
 class MockCluster: Clusterable {
+    var places: [Place] = []
+    
+    var bounds: CoordinateBounds = CoordinateBounds(southWestLng: 0, northEastLng: 0, southWestLat: 0, northEastLat: 0)
+    
+    var clusters: [Cluster] = []
+    
+    func run() {
+        clusters = execute(places: places, bounds: bounds)
+    }
+    
+    func copy(with zone: NSZone? = nil) -> Any {
+        let copy = MockCluster()
+        return copy
+    }
     
     func execute(places: [Place], bounds: CoordinateBounds) -> [Cluster] {
         return []

--- a/NaverMapA/NaverMapA/Model/Algorithm/Clusterable.swift
+++ b/NaverMapA/NaverMapA/Model/Algorithm/Clusterable.swift
@@ -12,7 +12,6 @@ protocol Clusterable: NSCopying {
     var bounds: CoordinateBounds { get set }
     var clusters: [Cluster] { get set }
     func execute(places: [Place], bounds: CoordinateBounds) -> [Cluster]
-    func run()
 }
 
 class MockCluster: Clusterable {
@@ -21,16 +20,10 @@ class MockCluster: Clusterable {
     var bounds: CoordinateBounds = CoordinateBounds(southWestLng: 0, northEastLng: 0, southWestLat: 0, northEastLat: 0)
     
     var clusters: [Cluster] = []
-    
-    func run() {
-        clusters = execute(places: places, bounds: bounds)
-    }
-    
     func copy(with zone: NSZone? = nil) -> Any {
         let copy = MockCluster()
         return copy
     }
-    
     func execute(places: [Place], bounds: CoordinateBounds) -> [Cluster] {
         return []
     }

--- a/NaverMapA/NaverMapA/Model/Algorithm/KMeansClustering.swift
+++ b/NaverMapA/NaverMapA/Model/Algorithm/KMeansClustering.swift
@@ -13,11 +13,6 @@ final class KMeansClustering: Operation, Clusterable {
     var bounds: CoordinateBounds = CoordinateBounds(southWestLng: 0, northEastLng: 0, southWestLat: 0, northEastLat: 0)
     
     var clusters: [Cluster] = []
-    
-    func run() {
-        clusters = execute(places: places, bounds: bounds)
-    }
-    
     func copy(with zone: NSZone? = nil) -> Any {
         let copy = KMeansClustering()
         return copy
@@ -27,21 +22,18 @@ final class KMeansClustering: Operation, Clusterable {
         if isCancelled {
             return
         }
-        run()
+        clusters = execute(places: places, bounds: bounds)
     }
     func execute(places: [Place], bounds: CoordinateBounds) -> [Cluster] {
-        if isCancelled {
-            return []
-        }
         let EXECUTE_TIMES = 3
         var centroids: [BasicCluster] = []
         let ks = (0..<5).map { _ in elbow(of: places.shuffled()) }
         let bestK = ks.max()
         let k = bestK ?? ks[0]
         var minTotalDistance = Double.greatestFiniteMagnitude
-        (0..<EXECUTE_TIMES).forEach { _ in
+        for _ in (0..<EXECUTE_TIMES) {
             if isCancelled {
-                return
+                return []
             }
             let temp = clustering(k: k, places: places.shuffled())
             let totalDistance = temp.reduce(0.0, {$0 + $1.totalDistance})
@@ -57,9 +49,6 @@ final class KMeansClustering: Operation, Clusterable {
     }
     
     private func optimalCentroids(k: Int, places: [Place]) -> [BasicCluster] {
-        if isCancelled {
-            return []
-        }
         let K_COUNT = k
         var centroids = [BasicCluster](repeating: BasicCluster(), count: K_COUNT)
         var optimals = BasicCluster()
@@ -71,9 +60,6 @@ final class KMeansClustering: Operation, Clusterable {
             var minDistance = Double.greatestFiniteMagnitude
             var indexOfNearest = 0
             for j in (0..<optimals.places.count) {
-                if isCancelled {
-                    return []
-                }
                 let distance = places[i].distanceTo(optimals.places[j])
                 if distance < minDistance {
                     minDistance = distance
@@ -90,20 +76,11 @@ final class KMeansClustering: Operation, Clusterable {
         (0..<K_COUNT).forEach {
             centroids[$0].places.append(optimals.places[$0])
         }
-        if isCancelled {
-            return []
-        }
         return centroids
     }
     private func clustering(k: Int, places: [Place]) -> [BasicCluster] {
-        if isCancelled {
-            return []
-        }
         let K_COUNT = k
         guard places.count > K_COUNT else {
-            if isCancelled {
-                return []
-            }
             let centroids: [BasicCluster] = places.map {
                 var centroid = BasicCluster()
                 centroid.places.append($0)
@@ -143,27 +120,27 @@ final class KMeansClustering: Operation, Clusterable {
         } while flag
         return centroids
     }
-
+    
     private func elbow(of places: [Place]) -> Int {
-        if isCancelled {
-            return 0
-        }
         var distances: [Double] = []
         let maxK = places.count > 10 ? 10 : places.count
         if maxK <= 3 { return maxK }
-        (1...maxK).forEach { K_COUNT in
+        for K_COUNT in (1...maxK) {
             if isCancelled {
-                return
+                return 0
             }
             var centroids = optimalCentroids(k: K_COUNT, places: places)
             var indexes = [Int](repeating: -1, count: places.count)
             var flag: Bool
             repeat {
                 if isCancelled {
-                    return
+                    return 0
                 }
                 flag = false
                 for i in (0..<places.count) {
+                    if isCancelled {
+                        return 0
+                    }
                     var minDistance = Double.greatestFiniteMagnitude
                     var indexOfNearest = 0
                     for (index, centroid) in centroids.enumerated() {
@@ -187,9 +164,6 @@ final class KMeansClustering: Operation, Clusterable {
             } while flag
             let totalDistance = centroids.reduce(0.0, {$0 + $1.totalDistance})
             distances.append(totalDistance)
-        }
-        if isCancelled {
-            return 0
         }
         var thetas: [(theta: Double, index: Int)] = []
         for i in (1..<(maxK-1)) { // 1~8 (양끝 0, 9 빼고)

--- a/NaverMapA/NaverMapA/Model/Algorithm/KMeansClustering.swift
+++ b/NaverMapA/NaverMapA/Model/Algorithm/KMeansClustering.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-
+/*
 final class KMeansClustering: Clusterable {
     func execute(places: [Place], bounds: CoordinateBounds) -> [Cluster] {
         let EXECUTE_TIMES = 3
@@ -143,3 +143,4 @@ final class KMeansClustering: Clusterable {
             (thetas[0].index + 1) : (thetas[1].index + 1)
     }
 }
+*/

--- a/NaverMapA/NaverMapA/Model/Algorithm/KMeansClustering.swift
+++ b/NaverMapA/NaverMapA/Model/Algorithm/KMeansClustering.swift
@@ -6,9 +6,33 @@
 //
 
 import Foundation
-/*
-final class KMeansClustering: Clusterable {
+
+final class KMeansClustering: Operation, Clusterable {
+    var places: [Place] = []
+    
+    var bounds: CoordinateBounds = CoordinateBounds(southWestLng: 0, northEastLng: 0, southWestLat: 0, northEastLat: 0)
+    
+    var clusters: [Cluster] = []
+    
+    func run() {
+        clusters = execute(places: places, bounds: bounds)
+    }
+    
+    func copy(with zone: NSZone? = nil) -> Any {
+        let copy = KMeansClustering()
+        return copy
+    }
+    
+    override func main() {
+        if isCancelled {
+            return
+        }
+        run()
+    }
     func execute(places: [Place], bounds: CoordinateBounds) -> [Cluster] {
+        if isCancelled {
+            return []
+        }
         let EXECUTE_TIMES = 3
         var centroids: [BasicCluster] = []
         let ks = (0..<5).map { _ in elbow(of: places.shuffled()) }
@@ -16,6 +40,9 @@ final class KMeansClustering: Clusterable {
         let k = bestK ?? ks[0]
         var minTotalDistance = Double.greatestFiniteMagnitude
         (0..<EXECUTE_TIMES).forEach { _ in
+            if isCancelled {
+                return
+            }
             let temp = clustering(k: k, places: places.shuffled())
             let totalDistance = temp.reduce(0.0, {$0 + $1.totalDistance})
             if totalDistance < minTotalDistance {
@@ -23,18 +50,30 @@ final class KMeansClustering: Clusterable {
                 centroids = temp
             }
         }
+        if isCancelled {
+            return []
+        }
         return centroids
     }
     
     private func optimalCentroids(k: Int, places: [Place]) -> [BasicCluster] {
+        if isCancelled {
+            return []
+        }
         let K_COUNT = k
         var centroids = [BasicCluster](repeating: BasicCluster(), count: K_COUNT)
         var optimals = BasicCluster()
         (0..<K_COUNT).forEach { optimals.places.append(places[$0]) }
         for i in (0..<places.count) {
+            if isCancelled {
+                return []
+            }
             var minDistance = Double.greatestFiniteMagnitude
             var indexOfNearest = 0
             for j in (0..<optimals.places.count) {
+                if isCancelled {
+                    return []
+                }
                 let distance = places[i].distanceTo(optimals.places[j])
                 if distance < minDistance {
                     minDistance = distance
@@ -51,11 +90,20 @@ final class KMeansClustering: Clusterable {
         (0..<K_COUNT).forEach {
             centroids[$0].places.append(optimals.places[$0])
         }
+        if isCancelled {
+            return []
+        }
         return centroids
     }
     private func clustering(k: Int, places: [Place]) -> [BasicCluster] {
+        if isCancelled {
+            return []
+        }
         let K_COUNT = k
         guard places.count > K_COUNT else {
+            if isCancelled {
+                return []
+            }
             let centroids: [BasicCluster] = places.map {
                 var centroid = BasicCluster()
                 centroid.places.append($0)
@@ -67,6 +115,9 @@ final class KMeansClustering: Clusterable {
         var indexes = [Int](repeating: -1, count: places.count)
         var flag: Bool
         repeat {
+            if isCancelled {
+                return []
+            }
             flag = false
             for i in (0..<places.count) {
                 var minDistance = Double.greatestFiniteMagnitude
@@ -94,14 +145,23 @@ final class KMeansClustering: Clusterable {
     }
 
     private func elbow(of places: [Place]) -> Int {
+        if isCancelled {
+            return 0
+        }
         var distances: [Double] = []
         let maxK = places.count > 10 ? 10 : places.count
         if maxK <= 3 { return maxK }
         (1...maxK).forEach { K_COUNT in
+            if isCancelled {
+                return
+            }
             var centroids = optimalCentroids(k: K_COUNT, places: places)
             var indexes = [Int](repeating: -1, count: places.count)
             var flag: Bool
             repeat {
+                if isCancelled {
+                    return
+                }
                 flag = false
                 for i in (0..<places.count) {
                     var minDistance = Double.greatestFiniteMagnitude
@@ -128,6 +188,9 @@ final class KMeansClustering: Clusterable {
             let totalDistance = centroids.reduce(0.0, {$0 + $1.totalDistance})
             distances.append(totalDistance)
         }
+        if isCancelled {
+            return 0
+        }
         var thetas: [(theta: Double, index: Int)] = []
         for i in (1..<(maxK-1)) { // 1~8 (양끝 0, 9 빼고)
             let diff1 = distances[i-1] - distances[i]
@@ -143,4 +206,3 @@ final class KMeansClustering: Clusterable {
             (thetas[0].index + 1) : (thetas[1].index + 1)
     }
 }
-*/

--- a/NaverMapA/NaverMapA/Model/Algorithm/ScaleBasedClustering.swift
+++ b/NaverMapA/NaverMapA/Model/Algorithm/ScaleBasedClustering.swift
@@ -6,9 +6,34 @@
 //
 
 import Foundation
-/*
-class ScaleBasedClustering: Clusterable {
+
+class ScaleBasedClustering: Operation, Clusterable {
+    var places: [Place] = []
+    
+    var bounds: CoordinateBounds = CoordinateBounds(southWestLng: 0, northEastLng: 0, southWestLat: 0, northEastLat: 0)
+    
+    var clusters: [Cluster] = []
+    
+    func run() {
+        clusters = execute(places: places, bounds: bounds)
+    }
+    
+    func copy(with zone: NSZone? = nil) -> Any {
+        let copy = ScaleBasedClustering()
+        return copy
+    }
+    
+    override func main() {
+        if isCancelled {
+            return
+        }
+        run()
+    }
+    
     func execute(places: [Place], bounds: CoordinateBounds) -> [Cluster] {
+        if isCancelled {
+            return []
+        }
         let mapScale = sqrt(pow(bounds.northEastLat - bounds.southWestLat, 2) + pow(bounds.northEastLng - bounds.southWestLng, 2)) / 12
         if places.count == 0 {
             return []
@@ -17,17 +42,29 @@ class ScaleBasedClustering: Clusterable {
         for place in places {
             clusterArray.append(BasicCluster(latitude: place.latitude, longitude: place.longitude, places: [place]))
         }
+        if isCancelled {
+            return []
+        }
         var isUpdate = true
         while isUpdate != false {
+            if isCancelled {
+                return []
+            }
             isUpdate = false
             var tempClusterArray = clusterArray
             clusterArray.removeAll()
             tempClusterArray.sort()
             while tempClusterArray.count != 0 {
+                if isCancelled {
+                    return []
+                }
                 var curPlace = tempClusterArray.removeFirst()
                 var clusterCount = tempClusterArray.count
                 var index = 0
                 while index < clusterCount {
+                    if isCancelled {
+                        return []
+                    }
                     if curPlace.distanceTo(tempClusterArray[index]) <= mapScale {
                         for tempPlace in tempClusterArray[index].places {
                             curPlace.places.append(tempPlace)
@@ -46,4 +83,3 @@ class ScaleBasedClustering: Clusterable {
         return clusterArray
     }
 }
-*/

--- a/NaverMapA/NaverMapA/Model/Algorithm/ScaleBasedClustering.swift
+++ b/NaverMapA/NaverMapA/Model/Algorithm/ScaleBasedClustering.swift
@@ -14,10 +14,6 @@ class ScaleBasedClustering: Operation, Clusterable {
     
     var clusters: [Cluster] = []
     
-    func run() {
-        clusters = execute(places: places, bounds: bounds)
-    }
-    
     func copy(with zone: NSZone? = nil) -> Any {
         let copy = ScaleBasedClustering()
         return copy
@@ -27,44 +23,29 @@ class ScaleBasedClustering: Operation, Clusterable {
         if isCancelled {
             return
         }
-        run()
+        clusters = execute(places: places, bounds: bounds)
     }
     
     func execute(places: [Place], bounds: CoordinateBounds) -> [Cluster] {
-        if isCancelled {
-            return []
-        }
         let mapScale = sqrt(pow(bounds.northEastLat - bounds.southWestLat, 2) + pow(bounds.northEastLng - bounds.southWestLng, 2)) / 12
         if places.count == 0 {
             return []
         }
         var clusterArray = [BasicCluster]()
-        for place in places {
+        for place in places where !isCancelled {
             clusterArray.append(BasicCluster(latitude: place.latitude, longitude: place.longitude, places: [place]))
         }
-        if isCancelled {
-            return []
-        }
         var isUpdate = true
-        while isUpdate != false {
-            if isCancelled {
-                return []
-            }
+        while isUpdate != false && !isCancelled {
             isUpdate = false
             var tempClusterArray = clusterArray
             clusterArray.removeAll()
             tempClusterArray.sort()
-            while tempClusterArray.count != 0 {
-                if isCancelled {
-                    return []
-                }
+            while tempClusterArray.count != 0 && !isCancelled {
                 var curPlace = tempClusterArray.removeFirst()
                 var clusterCount = tempClusterArray.count
                 var index = 0
-                while index < clusterCount {
-                    if isCancelled {
-                        return []
-                    }
+                while index < clusterCount && !isCancelled {
                     if curPlace.distanceTo(tempClusterArray[index]) <= mapScale {
                         for tempPlace in tempClusterArray[index].places {
                             curPlace.places.append(tempPlace)
@@ -80,6 +61,6 @@ class ScaleBasedClustering: Operation, Clusterable {
                 clusterArray.append(curPlace)
             }
         }
-        return clusterArray
+        return isCancelled ? [] : clusterArray
     }
 }

--- a/NaverMapA/NaverMapA/Model/Algorithm/ScaleBasedClustering.swift
+++ b/NaverMapA/NaverMapA/Model/Algorithm/ScaleBasedClustering.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-
+/*
 class ScaleBasedClustering: Clusterable {
     func execute(places: [Place], bounds: CoordinateBounds) -> [Cluster] {
         let mapScale = sqrt(pow(bounds.northEastLat - bounds.southWestLat, 2) + pow(bounds.northEastLng - bounds.southWestLng, 2)) / 12
@@ -46,3 +46,4 @@ class ScaleBasedClustering: Clusterable {
         return clusterArray
     }
 }
+*/

--- a/NaverMapA/NaverMapA/ViewModel/MainViewModel.swift
+++ b/NaverMapA/NaverMapA/ViewModel/MainViewModel.swift
@@ -17,11 +17,10 @@ class MainViewModel {
     init(algorithm: Clusterable) {
         clusteringAlgorithm = algorithm
     }
-    
     func updatePlaces(places: [Place], bounds: CoordinateBounds) {
         queue.cancelAllOperations()
         let clusteringAlgorithm = self.clusteringAlgorithm.copy()
-        guard let cluster = clusteringAlgorithm as? PenaltyKmeans else {
+        guard let cluster = clusteringAlgorithm as? Clusterable else {
             return
         }
         cluster.places = places

--- a/NaverMapA/NaverMapA/ViewModel/MainViewModel.swift
+++ b/NaverMapA/NaverMapA/ViewModel/MainViewModel.swift
@@ -13,20 +13,42 @@ class MainViewModel {
     var animationMarkers: Dynamic<([Cluster], [Cluster])> = Dynamic(([], []))
     var clusteringAlgorithm: Clusterable
     var beforeMarkers: [Cluster] = []
-    
+    let queue = OperationQueue()
     init(algorithm: Clusterable) {
         clusteringAlgorithm = algorithm
     }
     
     func updatePlaces(places: [Place], bounds: CoordinateBounds) {
-        DispatchQueue.global().async {
-            self.markers.value = self.clusteringAlgorithm.execute(places: places, bounds: bounds)
+        queue.cancelAllOperations()
+        let clusteringAlgorithm = self.clusteringAlgorithm.copy()
+        guard let cluster = clusteringAlgorithm as? PenaltyKmeans else {
+            return
+        }
+        cluster.places = places
+        cluster.bounds = bounds
+        guard let operation = clusteringAlgorithm as? Operation else {
+            return
+        }
+        queue.addOperation(operation)
+        queue.addBarrierBlock {
+            self.markers.value = cluster.clusters
         }
     }
     
     func updatePlacesAndAnimation(places: [Place], bounds: CoordinateBounds) {
-        DispatchQueue.global().async {
-            var newClusters = self.clusteringAlgorithm.execute(places: places, bounds: bounds)
+        queue.cancelAllOperations()
+        let clusteringAlgorithm = self.clusteringAlgorithm.copy()
+        guard let cluster = clusteringAlgorithm as? Clusterable else {
+            return
+        }
+        cluster.places = places
+        cluster.bounds = bounds
+        guard let operation = clusteringAlgorithm as? Operation else {
+            return
+        }
+        queue.addOperation(operation)
+        queue.addBarrierBlock {
+            var newClusters = cluster.clusters
             for index in 0..<newClusters.count {
                 newClusters[index].placesDictionary.removeAll()
                 newClusters[index].places.forEach { place in


### PR DESCRIPTION
## Feat
- 지도 이동 / 확대 / 축소 시 클러스터링 연산이 중복되는 것을 해결
- Operation Queue를 활용해 Cancel을 날려줌 

## Operation Queue
- cancelAllOperations 해도 멈추지 않음 => 단순히 해당 opertion에 알려만 주는 것
- 따라서 패널티 알고리즘이나 K-mean의 경우 K값을 찾거나 패널티 값 찾을때 지속적으로 cancel 됐는지 확인 후 처리해야함.
- opeartion을 쓰려면 main을 오버라이딩 받아야함
- 그러기 위해 기존에는 excute 함수에서 매개변수로 처리해 반환했으나, 현재는 매개변수의 경우 operation 시작 전에 넣어주고 operation이 끝나면 addBarrierBlock을 통해 데이터를 반환 받음.

- **addBarrier 사용을 위해 우리 앱은 iOS 13+로 변경**

## Bug Fix
- operationQueue의 경우 같은 작업이 2번 이상 불리면 throw함.
- 이걸 해결하기 위해 NSCopy Protocol을 활용해 Deep Copy 구현.