### PR TITLE
penalty Kmeans의 MaxK값 결정 방식 수정

### DIFF
--- a/NaverMapA/NaverMapA/Model/Algorithm/penaltyKmeans.swift
+++ b/NaverMapA/NaverMapA/Model/Algorithm/penaltyKmeans.swift
@@ -8,19 +8,21 @@
 import Foundation
 
 final class PenaltyKmeans: Operation, Clusterable {
+    
     var places: [Place] = []
     var bounds: CoordinateBounds = CoordinateBounds(southWestLng: 0, northEastLng: 0, southWestLat: 0, northEastLat: 0)
     var clusters: [Cluster] = []
-    func copy(with zone: NSZone? = nil) -> Any {
-        let copy = PenaltyKmeans()
-        return copy
-    }
 
     override func main() {
         if isCancelled {
             return
         }
         clusters = execute(places: places, bounds: bounds)
+    }
+    
+    func copy(with zone: NSZone? = nil) -> Any {
+        let copy = PenaltyKmeans()
+        return copy
     }
     
     func execute(places: [Place], bounds: CoordinateBounds) -> [Cluster] {
@@ -34,7 +36,7 @@ final class PenaltyKmeans: Operation, Clusterable {
         return bestCluster(clusters: candidateCluster, count: places.count)
     }
     
-    func bestCluster(clusters: [[PenaltyCluster]], count: Int) -> [PenaltyCluster] {
+    private func bestCluster(clusters: [[PenaltyCluster]], count: Int) -> [PenaltyCluster] {
         guard clusters.count != 0 else { return [] }
         var distances = clusters.map { candidate in
             candidate.reduce(0.0, { $0 + $1.totalDistance })
@@ -56,7 +58,7 @@ final class PenaltyKmeans: Operation, Clusterable {
         return isCancelled ? [] : clusters[minIdx]
     }
     
-    func clustering(places: [Place], k: Int) -> [PenaltyCluster] {
+    private func clustering(places: [Place], k: Int) -> [PenaltyCluster] {
         var centroids = initialCentroid(k: k, places: places)
         let iterationCount = 5
         centroids = distributeToCentroid(places: places, centroids: centroids)
@@ -71,7 +73,7 @@ final class PenaltyKmeans: Operation, Clusterable {
             .filter { $0.places.count > 0 }
     }
     
-    func initialCentroid(k: Int, places: [Place]) -> [PenaltyCluster] {
+    private func initialCentroid(k: Int, places: [Place]) -> [PenaltyCluster] {
         let initialRandomCentroid = (0..<k).map { _ -> Place in
             let idx = Int.random(in: 0..<places.count)
             return places[idx]
@@ -92,7 +94,7 @@ final class PenaltyKmeans: Operation, Clusterable {
         return centroidToCluster
     }
     
-    func distributeToCentroid(places: [Place], centroids: [PenaltyCluster]) -> [PenaltyCluster] {
+    private func distributeToCentroid(places: [Place], centroids: [PenaltyCluster]) -> [PenaltyCluster] {
         let distributedCentroid = centroids
         
         for place in places where !isCancelled {
@@ -104,7 +106,7 @@ final class PenaltyKmeans: Operation, Clusterable {
         return distributedCentroid
     }
     
-    func determinateMaxK(count: Int) -> Int {
+    private func determinateMaxK(count: Int) -> Int {
         let MAXOPERATION: Double = 250000
         let a: Double = 5
         let b: Double = 1

--- a/NaverMapA/NaverMapA/Model/Algorithm/penaltyKmeans.swift
+++ b/NaverMapA/NaverMapA/Model/Algorithm/penaltyKmeans.swift
@@ -107,7 +107,7 @@ final class PenaltyKmeans: Operation, Clusterable {
     }
     
     private func determinateMaxK(count: Int) -> Int {
-        let MAXOPERATION: Double = 250000
+        let MAXOPERATION: Double = 125000
         let a: Double = 5
         let b: Double = 1
         let c: Double = MAXOPERATION / Double(count)

--- a/NaverMapA/NaverMapA/Model/Algorithm/penaltyKmeans.swift
+++ b/NaverMapA/NaverMapA/Model/Algorithm/penaltyKmeans.swift
@@ -33,10 +33,10 @@ final class PenaltyKmeans: Operation, Clusterable {
             let clusters = clustering(places: places, k: k)
             candidateCluster.append(clusters)
         }
-        return bestCluster(clusters: candidateCluster, count: places.count)
+        return bestCluster(clusters: candidateCluster)
     }
     
-    private func bestCluster(clusters: [[PenaltyCluster]], count: Int) -> [PenaltyCluster] {
+    private func bestCluster(clusters: [[PenaltyCluster]]) -> [PenaltyCluster] {
         guard clusters.count != 0 else { return [] }
         var distances = clusters.map { candidate in
             candidate.reduce(0.0, { $0 + $1.totalDistance })
@@ -104,7 +104,7 @@ final class PenaltyKmeans: Operation, Clusterable {
         for place in places where !isCancelled {
             let nearCluster = distributedCentroid
                 .min { $0.distanceTo(place) < $1.distanceTo(place) }
-            nearCluster?.append(jsonPlace: place)
+            nearCluster?.append(place: place)
         }
         
         return distributedCentroid

--- a/NaverMapA/NaverMapA/Model/Algorithm/penaltyKmeans.swift
+++ b/NaverMapA/NaverMapA/Model/Algorithm/penaltyKmeans.swift
@@ -66,7 +66,11 @@ final class PenaltyKmeans: Operation, Clusterable {
         for _ in 0..<iterationCount {
             var newCentroids = centroids.map { PenaltyCluster(lat: $0.latitude, lng: $0.longitude, places: [])}
             newCentroids = distributeToCentroid(places: places, centroids: newCentroids)
-            centroids = newCentroids
+            centroids = newCentroids.map {
+                PenaltyCluster(lat: $0.averageLatitude,
+                               lng: $0.averageLongitude,
+                               places: $0.places )
+            }
         }
         return centroids
             .map { PenaltyCluster(lat: $0.latitude, lng: $0.longitude, places: $0.places)}

--- a/NaverMapA/NaverMapA/Model/Algorithm/penaltyKmeans.swift
+++ b/NaverMapA/NaverMapA/Model/Algorithm/penaltyKmeans.swift
@@ -78,9 +78,8 @@ final class PenaltyKmeans: Operation, Clusterable {
     }
     
     private func initialCentroid(k: Int, places: [Place]) -> [PenaltyCluster] {
-        let initialRandomCentroid = (0..<k).map { _ -> Place in
-            let idx = Int.random(in: 0..<places.count)
-            return places[idx]
+        let initialRandomCentroid = (0..<k).map {
+            return places[$0]
         }
         var centerOfCentroid = PenaltyCluster(places: initialRandomCentroid)
         

--- a/NaverMapA/NaverMapA/Model/Cluster/PenaltyCluster.swift
+++ b/NaverMapA/NaverMapA/Model/Cluster/PenaltyCluster.swift
@@ -13,7 +13,13 @@ class PenaltyCluster: Cluster, Equatable {
     var longitude: Double
     var places: [Place]
     var placesDictionary: [Point: Int] = [:]
-
+    var averageLatitude: Double {
+        return places.reduce(0.0, {$0 + $1.latitude}) / Double(places.count)
+    }
+    var averageLongitude: Double {
+        return places.reduce(0.0, {$0 + $1.longitude}) / Double(places.count)
+    }
+    
     init(places: [Place]) {
         self.places = places
         latitude = places.reduce(0, { $0 + $1.latitude }) / Double(places.count)

--- a/NaverMapA/NaverMapA/Model/Cluster/PenaltyCluster.swift
+++ b/NaverMapA/NaverMapA/Model/Cluster/PenaltyCluster.swift
@@ -32,11 +32,8 @@ class PenaltyCluster: Cluster, Equatable {
         self.places = places
     }
     
-    func append(jsonPlace: Place) {
-        let count = places.count
-        latitude = (Double(count)*latitude + jsonPlace.latitude) / Double(count + 1)
-        longitude = (Double(count)*longitude + jsonPlace.longitude) / Double(count + 1)
-        places.append(jsonPlace)
+    func append(place: Place) {
+        places.append(place)
     }
     
     func clearPlaces() {

--- a/NaverMapA/NaverMapA/Model/Place/PlaceProvider.swift
+++ b/NaverMapA/NaverMapA/Model/Place/PlaceProvider.swift
@@ -78,6 +78,7 @@ class PlaceProvider {
         let lngPredict = NSPredicate(format: "longitude >= %lf && longitude <= %lf", minLng, maxLng)
         let latPredict = NSPredicate(format: "latitude >= %lf && latitude <= %lf", minLat, maxLat)
         fetchRequest.predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [lngPredict, latPredict])
+        fetchRequest.returnsObjectsAsFaults = false
         return (try? mainContext.fetch(fetchRequest)) ?? []
     }
     


### PR DESCRIPTION
## feat

#### 최대 K의 값 설정해주는 방식을 기존에는 축적에 따라 해주었다면 place의 개수에 따라 결정하도록 변경

penalty 클러스터링 알고리즘의 시간복잡도를 구해본 결과 5nk^2 + nk의 복잡도를 가짐 
위의 복잡도에서 값이 MAXOPERATION 120000을 넘지 않는 최대의 K를 Maximum K로 결정
MAXOPERATION이 120000인 이유는 값을 바꿔가며 돌려보았을 때 평균 계산시간이 ~~13ms~~ (130ms인것 같네요 ?)가 되는 값이기 때문

``` swift
public func measureTime(_ closure: () -> ()) -> TimeInterval {
    let startDate = Date()
    closure()
    return Date().timeIntervalSince(startDate)
}
```
시간측정은 위의 함수를 이용하였습니다


<img width="443" alt="스크린샷 2020-12-07 오후 5 24 46" src="https://user-images.githubusercontent.com/46335714/101327214-bb705480-38b1-11eb-9623-4543b1579f12.png">

#### 더 의논하고 싶은점
더 개선해야할 부분이 있을까요 ? 
제가 봤을때 보이는 부분은 Kmeans의 중심을 이동하는 부분을 5번하는데 하는데 있어서 place를 초기화 해주었다가 다시 할당을 해주는데 이부분을 개선하면 좀 효과가 있을지.. 