### PR TITLE
PullUpView interaction 개선

### DIFF
--- a/NaverMapA/NaverMapA/Controller/DetailPullUpViewController.swift
+++ b/NaverMapA/NaverMapA/Controller/DetailPullUpViewController.swift
@@ -23,6 +23,7 @@ class DetailPullUpViewController: UIViewController {
     }
     
     private let panGestureVelocityThreshold: CGFloat = 200
+    private let animationDuration = 0.4
 
     // MARK: - Properties
     
@@ -64,7 +65,7 @@ class DetailPullUpViewController: UIViewController {
     }
     
     override func viewWillAppear(_ animated: Bool) {
-        UIView.animate(withDuration: 0.4, animations: { [weak self] in
+        UIView.animate(withDuration: animationDuration, animations: { [weak self] in
             guard let self = self else { return }
             self.moveView(state: .short)
         })
@@ -168,7 +169,7 @@ class DetailPullUpViewController: UIViewController {
     @objc private func panGesture(_ recognizer: UIPanGestureRecognizer) {
         moveView(panGestureRecognizer: recognizer)
         guard recognizer.state == .ended else { return }
-        UIView.animate(withDuration: 0.4, animations: { [weak self] in
+        UIView.animate(withDuration: animationDuration, animations: { [weak self] in
             guard let self = self else { return }
             let maxY = UIScreen.main.bounds.height
             let yPosition = self.view.frame.minY
@@ -234,7 +235,7 @@ extension DetailPullUpViewController: UICollectionViewDelegate {
             }()
             self.cluster = newCluster
         }
-        UIView.animate(withDuration: 0.5, animations: { [weak self] in
+        UIView.animate(withDuration: animationDuration, animations: { [weak self] in
             guard let self = self else { return }
             self.moveView(state: .half)
         })

--- a/NaverMapA/NaverMapA/Controller/DetailPullUpViewController.swift
+++ b/NaverMapA/NaverMapA/Controller/DetailPullUpViewController.swift
@@ -62,7 +62,7 @@ class DetailPullUpViewController: UIViewController {
     }
     
     override func viewWillAppear(_ animated: Bool) {
-        UIView.animate(withDuration: 0.5, animations: { [weak self] in
+        UIView.animate(withDuration: 0.4, animations: { [weak self] in
             guard let self = self else { return }
             self.moveView(state: .short)
         })
@@ -166,7 +166,7 @@ class DetailPullUpViewController: UIViewController {
     @objc private func panGesture(_ recognizer: UIPanGestureRecognizer) {
         moveView(panGestureRecognizer: recognizer)
         guard recognizer.state == .ended else { return }
-        UIView.animate(withDuration: 0.5, animations: { [weak self] in
+        UIView.animate(withDuration: 0.4, animations: { [weak self] in
             guard let self = self else { return }
             let maxY = UIScreen.main.bounds.height
             let yPosition = self.view.frame.minY

--- a/NaverMapA/NaverMapA/Controller/DetailPullUpViewController.swift
+++ b/NaverMapA/NaverMapA/Controller/DetailPullUpViewController.swift
@@ -21,6 +21,8 @@ class DetailPullUpViewController: UIViewController {
         case half
         case short
     }
+    
+    private let panGestureVelocityThreshold: CGFloat = 200
 
     // MARK: - Properties
     
@@ -171,7 +173,7 @@ class DetailPullUpViewController: UIViewController {
             let maxY = UIScreen.main.bounds.height
             let yPosition = self.view.frame.minY
             let velocity = recognizer.velocity(in: self.view)
-            if abs(velocity.y) > abs(velocity.x) && abs(velocity.y) > 200 {
+            if abs(velocity.y) > abs(velocity.x) && abs(velocity.y) > self.panGestureVelocityThreshold {
                 if velocity.y < 0 {
                     if yPosition <= self.halfViewPosition {
                         self.moveView(state: .full)

--- a/NaverMapA/NaverMapA/Controller/DetailPullUpViewController.swift
+++ b/NaverMapA/NaverMapA/Controller/DetailPullUpViewController.swift
@@ -170,6 +170,25 @@ class DetailPullUpViewController: UIViewController {
             guard let self = self else { return }
             let maxY = UIScreen.main.bounds.height
             let yPosition = self.view.frame.minY
+            let velocity = recognizer.velocity(in: self.view)
+            if abs(velocity.y) > abs(velocity.x) && abs(velocity.y) > 200 {
+                if velocity.y < 0 {
+                    if yPosition <= self.halfViewPosition {
+                        self.moveView(state: .full)
+                    } else
+                    if yPosition <= self.shortViewPosition {
+                        self.moveView(state: .half)
+                    }
+                } else {
+                    if yPosition >= self.halfViewPosition {
+                        self.moveView(state: .short)
+                    } else
+                    if yPosition >= self.fullViewPosition {
+                        self.moveView(state: .half)
+                    }
+                }
+                return
+            }
             if yPosition <= maxY / 3.0 {
                 self.moveView(state: .full)
             } else if yPosition <= maxY / 3.0 * 2.0 {


### PR DESCRIPTION
### 변경사항
- 기존에는 PanGesture가 ended 되는 시점(뷰를 잡고 끌다가 마우스를 떼는 시점)의 y좌표가 화면을 3등분한 구역(short, half, full) 중 해당되는 곳으로 달라붙도록 했음.
- 애플 지도를 확인해보니, 위와 같은 Interaction에 더하여 위, 아래 방향으로 탭하듯이 짧게 스와이프하면 위나 아래로 달라붙도록 함.
- PanGesture의 속도를 체크해서 기준 속도 `200`을 넘으면 슉슉 달라붙도록 함...

Close #54

<img height="600" src="https://user-images.githubusercontent.com/44656036/101446695-187a1200-3967-11eb-812d-b011c0b6dce0.gif">     <img height="600" src="https://user-images.githubusercontent.com/44656036/101446717-2465d400-3967-11eb-8eab-4ec9c7c99c05.gif">      

