### PR TITLE
[fix] 움직일 때 beforeMarkers에 넣는 방식으로 해결

### DIFF
--- a/NaverMapA/NaverMapA/ViewModel/MainViewModel.swift
+++ b/NaverMapA/NaverMapA/ViewModel/MainViewModel.swift
@@ -32,6 +32,7 @@ class MainViewModel {
         queue.addOperation(operation)
         queue.addBarrierBlock {
             guard !operation.isCancelled else { return }
+            self.beforeMarkers = cluster.clusters
             self.markers.value = cluster.clusters
         }
     }


### PR DESCRIPTION
## Problem
- 최초에 줌인 / 줌아웃 애니메이션을 하면 애니메이션이 안된다.
- 이동 후 줌인 / 줌아웃 애니메이션을 해도 엉뚱한 곳만 된다.

## Answer
- 이동 시 beforeMarkers에 데이터를 넣어주지 않아서 생기는 버그였다.